### PR TITLE
Cater for parsing multiline traps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+MYMETA.json
+MYMETA.yml
+Makefile
+blib/
+pm_to_blib

--- a/Changes
+++ b/Changes
@@ -1,5 +1,9 @@
 Revision history for Perl extension SNMP::Trapinfo
 
+1.04 0000-00-00
+    Added 'eval { ... }' to enable some calculations 
+      Example: $result = $cp->expand( 'eval { sprintf("%.2f", ${V6} / ${V9} ) }');
+
 1.03 2014-09-22
     Added option to hide passwords on read of the packet
     Added rv2gv in Safe compartment, which is needed from perl 5.18 onwards

--- a/Changes
+++ b/Changes
@@ -2,6 +2,7 @@ Revision history for Perl extension SNMP::Trapinfo
 
 1.04 ????-??-??
     Added parsing of multiline traps, where lines are quoted using "
+    Fix expanding of '"${V10}"' being returned as '""value""' when value is already quoted in the trap
 
 1.03 2014-09-22
     Added option to hide passwords on read of the packet

--- a/Changes
+++ b/Changes
@@ -2,7 +2,6 @@ Revision history for Perl extension SNMP::Trapinfo
 
 1.04 ????-??-??
     Added parsing of multiline traps, where lines are quoted using "
-    Fix expanding of '"${V10}"' being returned as '""value""' when value is already quoted in the trap
 
 1.03 2014-09-22
     Added option to hide passwords on read of the packet

--- a/Changes
+++ b/Changes
@@ -1,5 +1,8 @@
 Revision history for Perl extension SNMP::Trapinfo
 
+1.04 ????-??-??
+    Added parsing of multiline traps, where lines are quoted using "
+
 1.03 2014-09-22
     Added option to hide passwords on read of the packet
     Added rv2gv in Safe compartment, which is needed from perl 5.18 onwards

--- a/lib/SNMP/Trapinfo.pm
+++ b/lib/SNMP/Trapinfo.pm
@@ -85,6 +85,14 @@ sub expand {
 			}
 		}
 
+        # if the string and newval both contains quotes then we can
+        # end up with returning '""value""'
+        # which eval doesn't like.  Look for this and change to return
+        # '"value"' instead
+        if($string =~ m/"\${$key}"/ && $newval =~ m/\A"(.*)"\Z/) {
+            $newval = $1;
+        }
+
 		# Must use same match as while loop
 		# Otherwise possible infinite loop
 		# though not sure why (see tests for examples)

--- a/lib/SNMP/Trapinfo.pm
+++ b/lib/SNMP/Trapinfo.pm
@@ -85,14 +85,6 @@ sub expand {
 			}
 		}
 
-        # if the string and newval both contains quotes then we can
-        # end up with returning '""value""'
-        # which eval doesn't like.  Look for this and change to return
-        # '"value"' instead
-        if($string =~ m/"\${$key}"/ && $newval =~ m/\A"(.*)"\Z/) {
-            $newval = $1;
-        }
-
 		# Must use same match as while loop
 		# Otherwise possible infinite loop
 		# though not sure why (see tests for examples)

--- a/lib/SNMP/Trapinfo.pm
+++ b/lib/SNMP/Trapinfo.pm
@@ -168,18 +168,18 @@ sub read {
 	$self->{packet} =~ s/\n*$//;
 	my @packet = split("\n", $self->{packet});
 	{
-		# go through the array and look for lines that might be joinable
-		# assume multi-lines are surrounded by quotes, so only one quote
+		# Go through the array and look for lines that might be joinable.
+		# Assume multi-lines are surrounded by quotes, so only one quote
 		# character means join the next line onto the current one
 
-		# Work from a copy of the packet incase we decide to make no changes
+		# Work from a copy of the packet in case we decide to make no changes
 		my @copy_packet = @packet;
 		my @new_packet;
 		my $within_quotes=0;
 		# use defined here to allow blank lines through
 		while( defined( my $line = shift @copy_packet)) {
 			if($within_quotes) {
-				$new_packet[-1] .= $line;
+				$new_packet[-1] .= "\n".$line;
 				my $quotes = $new_packet[-1] =~ tr/"/"/;
 				$within_quotes = 0 if( $quotes % 2 == 0 );
 				next;
@@ -193,7 +193,7 @@ sub read {
 			}
 		}
 
-		# Only rewrite the packet is it looks like we correctly
+		# Only rewrite the packet if it looks like we have correctly
 		# joined up all the lines
 		@packet=@new_packet if($within_quotes == 0 );
 	}
@@ -214,7 +214,7 @@ sub read {
 	foreach $_ (@packet) {
 		$i++;
 		# Ignore spaces in middle
-		my ($key, $value) = /^([^ ]+) +([^ ].*)$/;
+		my ($key, $value) = /^([^ ]+) +([^ ].*)$/s;
 		# If syntax is wrong, ignore this line
 		next unless defined $key;
 		$key = $self->cleanup_string($key);

--- a/lib/SNMP/Trapinfo.pm
+++ b/lib/SNMP/Trapinfo.pm
@@ -364,6 +364,13 @@ Any trailing linefeeds will be stripped.
 Apart from the first two lines, expects each line to be of the format: key value. If not, then will silently ignore
 the line.
 
+The value can be enclosed with double quotes and the quoted value may contain multiple lines
+
+  SNMPv2-SMI::enterprises.12345.1.1.1 = STRING: "
+  Alert Name: Multiple login failures detected
+  Current value: 10.0
+  Threshold: 2.0"
+
 If you want to use multiple packets within a stream, you have to put a marker in between
 each trap: "#---next trap---#\n". Then call SNMP::Trapinfo->new(*STDIN) again. Will receive an undef if 
 there are no more packets to read or the packet is malformed (such as no IP on the 2nd line).

--- a/lib/SNMP/Trapinfo.pm
+++ b/lib/SNMP/Trapinfo.pm
@@ -468,6 +468,18 @@ this would return:
 
   Port 2 (ifType=ppp) is Up with message "PPP LCP Open"
 
+It is also possible to perform calculations between values within C<expand()>.  For example:
+
+  $result = $trap->expand('eval { ${V5} * ${V8} }');
+  $result = $trap->expand('eval { ${V10} * ${V9} / 100 }');
+  $result = $trap->expand('eval { sprintf("%.2f", ${V3} / ${V4} ) }');
+
+Invalid calculations will return empty strings.
+
+  $result = $trap->expand('eval{ ${V5} / 0 }');  # divide by zero
+  $result = $trap->expand('eval{ ${V10} * 1 }'); # where V10 is empty
+  $result = $trap->expand('eval{ ${V10  }');     # mismatched braces
+
 =item eval($string)
 
 $string is passed into expand to expand any macros. Then the entire string is eval'd.

--- a/t/SNMP-Trapinfo.t
+++ b/t/SNMP-Trapinfo.t
@@ -5,7 +5,7 @@
 
 # change 'tests => 1' to 'tests => last_test_to_print';
 
-use Test::More tests => 100;
+use Test::More tests => 107;
 BEGIN { use_ok('SNMP::Trapinfo') };
 
 #########################
@@ -332,3 +332,13 @@ like( $@, '/Bad ref/', "Complain if bad parameters for new()");
 
 $trap = SNMP::Trapinfo->new(\$data);
 cmp_ok( $trap->hostip, 'eq', "192.168.10.21", "Host ip correct");
+
+cmp_ok( $trap->expand('eval { ${V5} * ${V5} }'), 'eq', 576, "simple eval expansion working" );
+cmp_ok( $trap->expand('eval { sprintf("%.2f", ${V5} * ${V5} ) }'), 'eq', "576.00", "eval expansion working with sprintf" );
+cmp_ok( $trap->expand('eval{${V5}*${V5}}'), 'eq', 576, "simple eval expansion working (no space)" );
+cmp_ok( $trap->expand('eval{sprintf("%.2f",${V5}*${V5})}'), 'eq', "576.00", "eval expansion working with sprintf (no space)" );
+
+# some invalid calcs
+cmp_ok( $trap->expand('eval{ ${V5} / 0 }'), 'eq', '', "divide by 0" );
+cmp_ok( $trap->expand('eval{ ${V10} * 1 }'), 'eq', '', "no such var" );
+cmp_ok( $trap->expand('eval{ ${V10  }'), 'eq', '', "bad braces" );

--- a/t/SNMP-Trapinfo.t
+++ b/t/SNMP-Trapinfo.t
@@ -6,7 +6,7 @@
 
 # change 'tests => 1' to 'tests => last_test_to_print';
 
-use Test::More tests => 114;
+use Test::More;
 BEGIN { use_ok('SNMP::Trapinfo') };
 
 #########################
@@ -364,7 +364,11 @@ cmp_ok( $trap->expand('${saatrap::saaEventName}'), 'eq', '"Message Sent"', "saat
 cmp_ok( $trap->expand('${SNMP-COMMUNITY-MIB::snmpTrapAddress}'), 'eq', '192.168.100.10', "SNMP-COMMUNITY-MIB::snmpTrapAddress is correct on multiline trap");
 cmp_ok( $trap->expand('${SNMPv2-MIB::snmpTrapEnterprise}'), 'eq', 'saatrap::saa', "SNMPv2-MIB::snmpTrapEnterprise is correct on multiline trap");
 cmp_ok( $trap->expand('${V16}'), 'eq', 'saatrap::saa', "V16 is correct on multiline trap");
-ok( $trap->expand('${saatrap::saaEventDescription}') =~ m/ABCDABCDABCDABCDABCDABCD123/, "saatrap::saaEventDescription contains data from multiple lines");
+is( $trap->expand('${saatrap::saaEventDescription}'), q{"Message Partner DataStoreIn, Session 2129 - Message sent
+    Sequence number : 1
+    UUMID           : ABCDABCDABCDABCDABCDABCD123
+    Suffix          : 1059726480192
+"}, "saatrap::saaEventDescription contains data from multiple lines");
 
 # make sure broken multiple lines do not stop reading the whole packet
 $data = <<EOF;
@@ -382,3 +386,5 @@ cmp_ok( $trap->expand('${saatrap::saaEventName}'), 'eq', '"Message Sent"', "saat
 cmp_ok( $trap->expand('${V5}'), 'eq', '"Message Sent"', "V5 is correct on broken multiline trap");
 cmp_ok( $trap->expand('${saatrap::saaEventClass}'), 'eq', '"Message', "saatrap::saaEventClass broken multiline can be read");
 cmp_ok( $trap->expand('${V4}'), 'eq', '"Message', "V4 broken multiline can be read");
+
+done_testing();

--- a/t/SNMP-Trapinfo.t
+++ b/t/SNMP-Trapinfo.t
@@ -6,7 +6,7 @@
 
 # change 'tests => 1' to 'tests => last_test_to_print';
 
-use Test::More tests => 115;
+use Test::More tests => 114;
 BEGIN { use_ok('SNMP::Trapinfo') };
 
 #########################
@@ -382,7 +382,3 @@ cmp_ok( $trap->expand('${saatrap::saaEventName}'), 'eq', '"Message Sent"', "saat
 cmp_ok( $trap->expand('${V5}'), 'eq', '"Message Sent"', "V5 is correct on broken multiline trap");
 cmp_ok( $trap->expand('${saatrap::saaEventClass}'), 'eq', '"Message', "saatrap::saaEventClass broken multiline can be read");
 cmp_ok( $trap->expand('${V4}'), 'eq', '"Message', "V4 broken multiline can be read");
-
-# be careful that ('"${V3}"') doesn't translate to '""Info""' which 'eval' cannot handle
-# but instead can be '"Info"' which is okay
-cmp_ok( $trap->expand('"${V3}"'), 'eq', '"Info"', 'Too many quotes removed');

--- a/t/SNMP-Trapinfo.t
+++ b/t/SNMP-Trapinfo.t
@@ -6,7 +6,7 @@
 
 # change 'tests => 1' to 'tests => last_test_to_print';
 
-use Test::More tests => 114;
+use Test::More tests => 115;
 BEGIN { use_ok('SNMP::Trapinfo') };
 
 #########################
@@ -382,3 +382,7 @@ cmp_ok( $trap->expand('${saatrap::saaEventName}'), 'eq', '"Message Sent"', "saat
 cmp_ok( $trap->expand('${V5}'), 'eq', '"Message Sent"', "V5 is correct on broken multiline trap");
 cmp_ok( $trap->expand('${saatrap::saaEventClass}'), 'eq', '"Message', "saatrap::saaEventClass broken multiline can be read");
 cmp_ok( $trap->expand('${V4}'), 'eq', '"Message', "V4 broken multiline can be read");
+
+# be careful that ('"${V3}"') doesn't translate to '""Info""' which 'eval' cannot handle
+# but instead can be '"Info"' which is okay
+cmp_ok( $trap->expand('"${V3}"'), 'eq', '"Info"', 'Too many quotes removed');


### PR DESCRIPTION
Some traps might have one element spread over multiple lines, such as:

hostname.somedomain
UDP: [192.168.100.10]:61613->[192.168.100.10]:162
DISMAN-EVENT-MIB::sysUpTimeInstance 0:0:00:00.01
SNMPv2-MIB::snmpTrapOID.0 saatrap::snmpSAAEvent
saatrap::saaEventName "Message Sent"
saatrap::saaEventDescription "Message Partner DataStoreIn, Session 2129 - Message sent
    Sequence number : 1
    UUMID           : ABCDABCDABCDABCDABCDABCD123
    Suffix          : 1059726480192
"
SNMP-COMMUNITY-MIB::snmpTrapAddress.0 192.168.100.10

This patch caters for reconstituting the lines where those lines are enclosed
with double quotes.  If only one quote is found from that point to the end of
the trap then the original packet is used, as now.

This patch also has the effect of fixing variable numbers as the multiple
lines are counted as variables in their own right, e.g. in the above $P11
is SNMP-COMMUNITY-MIB::snmpTrapAddress, not the expected $P7
