### PR TITLE
Quoting fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+MYMETA.json
+MYMETA.yml
+Makefile
+blib/
+pm_to_blib

--- a/Changes
+++ b/Changes
@@ -2,6 +2,7 @@ Revision history for Perl extension SNMP::Trapinfo
 
 1.04 ????-??-??
     Added parsing of multiline traps, where lines are quoted using "
+    Fix expanding of '"${V10}"' being returned as '""value""' when value is already quoted in the trap
 
 1.03 2014-09-22
     Added option to hide passwords on read of the packet

--- a/Changes
+++ b/Changes
@@ -1,5 +1,8 @@
 Revision history for Perl extension SNMP::Trapinfo
 
+1.04 ????-??-??
+    Added parsing of multiline traps, where lines are quoted using "
+
 1.03 2014-09-22
     Added option to hide passwords on read of the packet
     Added rv2gv in Safe compartment, which is needed from perl 5.18 onwards

--- a/lib/SNMP/Trapinfo.pm
+++ b/lib/SNMP/Trapinfo.pm
@@ -85,6 +85,14 @@ sub expand {
 			}
 		}
 
+        # if the string and newval both contains quotes then we can
+        # end up with returning '""value""'
+        # which eval doesn't like.  Look for this and change to return
+        # '"value"' instead
+        if($string =~ m/"\${$key}"/ && $newval =~ m/\A"(.*)"\Z/) {
+            $newval = $1;
+        }
+
 		# Must use same match as while loop
 		# Otherwise possible infinite loop
 		# though not sure why (see tests for examples)

--- a/t/SNMP-Trapinfo.t
+++ b/t/SNMP-Trapinfo.t
@@ -6,7 +6,7 @@
 
 # change 'tests => 1' to 'tests => last_test_to_print';
 
-use Test::More tests => 114;
+use Test::More tests => 115;
 BEGIN { use_ok('SNMP::Trapinfo') };
 
 #########################
@@ -382,3 +382,7 @@ cmp_ok( $trap->expand('${saatrap::saaEventName}'), 'eq', '"Message Sent"', "saat
 cmp_ok( $trap->expand('${V5}'), 'eq', '"Message Sent"', "V5 is correct on broken multiline trap");
 cmp_ok( $trap->expand('${saatrap::saaEventClass}'), 'eq', '"Message', "saatrap::saaEventClass broken multiline can be read");
 cmp_ok( $trap->expand('${V4}'), 'eq', '"Message', "V4 broken multiline can be read");
+
+# be careful that ('"${V3}"') doesn't translate to '""Info""' which 'eval' cannot handle
+# but instead can be '"Info"' which is okay
+cmp_ok( $trap->expand('"${V3}"'), 'eq', '"Info"', 'Too many quotes removed');


### PR DESCRIPTION
Building on the multiline traps commit, fix expanding of '"${V10}"' being returned as '""value""' when value is already quoted in the trap
